### PR TITLE
Do not add BuoyancyControl to ThrottleControlledAvionics "parts"

### DIFF
--- a/GameData/XyphosAerospace/Plugins/BuoyancyControl/BuoyancyControl.cfg
+++ b/GameData/XyphosAerospace/Plugins/BuoyancyControl/BuoyancyControl.cfg
@@ -1,4 +1,4 @@
-@PART[*]
+@PART[*]:HAS[~name[TCAModule*]]
 {
 	MODULE
 	{


### PR DESCRIPTION
ThrottleControlledAvionics uses dummy parts for tech tree unlocks of its modules.
Do not add BuoyancyControl to them.